### PR TITLE
feat: add states support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ This will create a new folder `my-cool-action` with the following files:
 * [The Toolkit class](#toolkit-options)
 * [Authenticated GitHub API client](#toolsgithub)
 * [Logging](#toolslog)
-* [Getting workflows' inputs](#toolsinputs)
+* [Getting workflow's inputs](#toolsinputs)
 * [Output information from your action](#toolsoutputs)
+* [Send values to pre / post actions](#toolsstates)
 * [Slash commands](#toolscommandcommand-args-match--promise)
 * [Reading files](#toolsreadfilepath-encoding--utf8)
 * [Run a CLI command](#toolsexec)
@@ -204,6 +205,19 @@ GitHub Actions workflows can define some "outputs" - options that can be passed 
 
 ```js
 tools.outputs.foo = 'bar'
+```
+
+_Note!_ This is not a plain object, it's an instance of [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy), so be aware that there may be some differences.
+
+<br>
+
+### tools.states
+
+GitHub Actions can send some "states" - options that can be passed to the pre or post action's scripts. You can access those using `tools.states`:
+
+```js
+tools.states.foo = 'bar'
+console.log(tools.states.foo) // -> 'bar'
 ```
 
 _Note!_ This is not a plain object, it's an instance of [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy), so be aware that there may be some differences.

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { Assert } from './assert'
 import { getBody } from './get-body'
 import { createInputProxy, InputType } from './inputs'
 import { createOutputProxy, OutputType } from './outputs'
+import { createStateProxy, StateType } from './states'
 
 export interface ToolkitOptions {
   /**
@@ -31,7 +32,7 @@ export interface ToolkitOptions {
   token?: string
 }
 
-export class Toolkit<I extends InputType = InputType, O extends OutputType = OutputType> {
+export class Toolkit<I extends InputType = InputType, O extends OutputType = OutputType, S extends StateType = StateType> {
   /**
    * Run an asynchronous function that accepts a toolkit as its argument, and fail if
    * an error occurs.
@@ -118,6 +119,11 @@ export class Toolkit<I extends InputType = InputType, O extends OutputType = Out
    */
   public outputs: O
 
+  /**
+   * An object of the states provided to your action. These can all be `undefined`!
+   */
+  public states: S
+
   constructor (opts: ToolkitOptions = {}) {
     this.opts = opts
 
@@ -135,6 +141,7 @@ export class Toolkit<I extends InputType = InputType, O extends OutputType = Out
     // Memoize our Proxy instance
     this.inputs = createInputProxy<I>()
     this.outputs = createOutputProxy<O>()
+    this.states = createStateProxy<S>()
 
     // Memoize the GitHub API token
     this.token = opts.token || this.inputs.github_token || process.env.GITHUB_TOKEN as string

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -1,4 +1,4 @@
-import * as core from '@actions/core'
+import { getEnvironmentVariable } from './utils'
 
 export interface InputType { [key: string]: string | undefined }
 
@@ -6,8 +6,8 @@ export function createInputProxy <I extends InputType = InputType>() {
   return new Proxy<I>({} as I, {
     get (_, name: string) {
       // When we attempt to get `inputs.___`, instead
-      // we call `core.getInput`.
-      return core.getInput(name)
+      // we call `getEnvironmentVariable`.
+      return getEnvironmentVariable('input', name)
     },
     getOwnPropertyDescriptor() {
       // We need to overwrite this to ensure that

--- a/src/states.ts
+++ b/src/states.ts
@@ -1,0 +1,27 @@
+import * as core from '@actions/core'
+
+export interface StateType { [key: string]: string | undefined }
+
+export function createStateProxy <S extends StateType = StateType>() {
+  return new Proxy<S>({} as S, {
+    get (_, name: string) {
+      // When we attempt to get `states.___`, instead
+      // we call `core.getState`.
+      return core.getState(name)
+    },
+    getOwnPropertyDescriptor() {
+      // We need to overwrite this to ensure that
+      // keys are enumerated
+      return {
+        enumerable: true,
+        configurable: true,
+        writable: false
+      }
+    },
+    ownKeys () {
+      const keys = Object.keys(process.env)
+      const filtered = keys.filter(key => key.startsWith('STATE_'))
+      return filtered
+    }
+  })
+}

--- a/src/states.ts
+++ b/src/states.ts
@@ -1,4 +1,4 @@
-import * as core from '@actions/core'
+import { getEnvironmentVariable } from './utils'
 
 export interface StateType { [key: string]: string | undefined }
 
@@ -6,8 +6,8 @@ export function createStateProxy <S extends StateType = StateType>() {
   return new Proxy<S>({} as S, {
     get (_, name: string) {
       // When we attempt to get `states.___`, instead
-      // we call `core.getState`.
-      return core.getState(name)
+      // we call `getEnvironmentVariable`.
+      return getEnvironmentVariable('state', name)
     },
     getOwnPropertyDescriptor() {
       // We need to overwrite this to ensure that

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,22 @@
+import { InputOptions } from "@actions/core"
+
+export type EnvironmentVariableType = 'input' | 'output' | 'state'
+
+/**
+ * Gets the value of an input / output / state variable. The value is also trimmed.
+ *
+ * @param     type     type of the variable
+ * @param     name     name of the variable
+ * @param     options  optional. See InputOptions.
+ * @returns   string | undefined
+ */
+export function getEnvironmentVariable(type: EnvironmentVariableType, name: string, options?: InputOptions): string | undefined {
+  const prefix = type.toUpperCase();
+  const upperCaseName = name.replace(/ /g, '_').toUpperCase();
+  const value = process.env[`${prefix}_${upperCaseName}`]
+  if (options?.required && value === undefined) {
+    throw new Error(`Input required and not supplied: ${name}`);
+  }
+
+  return value?.trim()
+}

--- a/tests/states.test.ts
+++ b/tests/states.test.ts
@@ -1,0 +1,50 @@
+import {createStateProxy, StateType} from '../src/states'
+
+describe('createStateProxy', () => {
+  let states: StateType
+
+  beforeEach(() => {
+    process.env.STATE_EXAMPLE = 'pizza'
+    process.env.STATE_FOO = 'bar'
+    process.env['STATE_EXAMPLE-NAME'] = 'pizza'
+    states = createStateProxy()
+  })
+
+  afterEach(() => {
+    delete process.env.STATE_EXAMPLE
+    delete process.env.STATE_FOO
+    delete process.env.STATE_EXAMPLE_NAME
+  })
+
+  describe('#get', () => {
+    it('returns the expected value', () => {
+      const result = states.example
+      expect(result).toBe('pizza')
+    })
+  
+    it('accepts the correct types', () => {
+      states = createStateProxy<{ example: string }>()
+      const result = states.example
+      expect(result).toBe('pizza')
+    })
+  
+    it('gets a property with a - in it', () => {
+      states = createStateProxy<{ 'example-name': string }>()
+      const result = states['example-name']
+      expect(result).toBe('pizza')
+    })
+  })
+
+  describe('#set', () => {
+    it('does not allow properties to be set', () => {
+      expect(() => states.test = 'test').toThrowError()
+    })
+  })
+
+  describe('#ownKeys', () => {
+    it('returns the filtered keys', () => {
+      const keys = Object.keys(states)
+      expect(keys).toEqual(['STATE_EXAMPLE-NAME', 'STATE_EXAMPLE', 'STATE_FOO'])
+    })
+  })
+})


### PR DESCRIPTION
**Why?**

Adds  [action state support](https://github.com/actions/toolkit/tree/main/packages/core#action-state) 

**How?**

This PR adds new **states** property to Toolkit class, similar to how it's done with **inputs** and **outputs** properties.

### Checks

- [x] Tests has been added
- [x] Documentation has been updated